### PR TITLE
adding WP-CLI support

### DIFF
--- a/enforce-single-category.php
+++ b/enforce-single-category.php
@@ -15,6 +15,9 @@
 // Call our namepsace.
 namespace EnforceSingleCategory;
 
+// Call our CLI namespace.
+use WP_CLI;
+
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
@@ -35,3 +38,13 @@ require_once __DIR__ . '/includes/helpers.php';
 require_once __DIR__ . '/includes/post-edit.php';
 require_once __DIR__ . '/includes/quick-edit.php';
 require_once __DIR__ . '/includes/save-post.php';
+
+// Check that we have the constant available.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+	// Load our commands file.
+	require_once __DIR__ . '/includes/commands.php';
+
+	// And add our command.
+	WP_CLI::add_command( 'enforce-singlecat', Commands::class );
+}

--- a/enforce-single-category.php
+++ b/enforce-single-category.php
@@ -43,7 +43,7 @@ require_once __DIR__ . '/includes/save-post.php';
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 	// Load our commands file.
-	require_once __DIR__ . '/includes/commands.php';
+	require_once dirname( __FILE__ ) . '/includes/commands.php';
 
 	// And add our command.
 	WP_CLI::add_command( 'enforce-singlecat', Commands::class );

--- a/includes/commands.php
+++ b/includes/commands.php
@@ -200,17 +200,19 @@ class Commands extends WP_CLI_Command {
 		// Get the actual count.
 		$count  = count( $posts );
 
-		// Prompt to continue the process if the autoloop wasn't set.
+		// Set the text for counts.
+		$ctext  = sprintf( _n( 'You have %d post with multiple categories assigned.', 'You have %d posts with multiple categories assigned.', absint( $count ), 'enforce-single-category' ), absint( $count ) );
+
+		// If we only wanted the counts, show that.
 		if ( $parsed['counts'] ) {
 
 			// Show the count and bail.
-			WP_CLI::success( sprintf( _n( 'You have %d post with multiple categories.', 'You have %d posts with multiple categories.', absint( $count ), 'enforce-single-category' ), absint( $count ) ) );
+			WP_CLI::success( $ctext );
 			WP_CLI::halt( 0 );
 		}
 
 		// Show the count as a context.
-		WP_CLI::log( sprintf( _n( 'You have %d post with multiple categories.', 'You have %d posts with multiple categories.', absint( $count ), 'enforce-single-category' ), absint( $count ) ) );
-		WP_CLI::log( '' );
+		WP_CLI::log( $ctext . "\n" );
 
 		// Set a counter.
 		$i = 0;

--- a/includes/commands.php
+++ b/includes/commands.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * The functionality tied to the WP-CLI stuff.
+ *
+ * @package EnforceSingleCategory
+ */
+
+// Call our namepsace.
+namespace EnforceSingleCategory\Commands;
+
+// Set our alias items.
+use EnforceSingleCategory\Helpers as Helpers;
+
+// Pull in the CLI items.
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Extend the CLI command class with our own.
+ */
+class Commands extends WP_CLI_Command {
+
+	/**
+	* Get the array of post IDs to check.
+	*
+	* @return array
+	*/
+	protected function get_post_ids() {
+
+		// Load the global DB.
+		global $wpdb;
+
+		// Set my table name to use.
+		$table  = $wpdb->prefix . 'posts';
+
+		// Set up our query.
+		$setup  = $wpdb->prepare("
+			SELECT   ID
+			FROM     $table
+			WHERE    post_status = '%s'
+			AND      post_type = '%s'
+			ORDER BY post_date DESC
+		", esc_sql( 'publish' ), esc_sql( 'post' ) );
+
+		// Process the query.
+		$ids    = $wpdb->get_col( $setup );
+
+		// Bail on empty or error.
+		if ( empty( $ids ) || is_wp_error( $ids ) ) {
+			WP_CLI::error( 'No post IDs could be retrieved.' );
+		}
+
+		// Set an empty data array.
+		$build  = array();
+
+		// Now loop my items.
+		foreach ( $ids as $id ) {
+
+			// Get the terms.
+			$terms  = wp_get_post_categories( $id, array( 'orderby' => 'count', 'order' => 'DESC' ) );
+
+			// Skip if empty or only 1.
+			if ( empty( $terms ) || count( $terms ) < 2 ) {
+				continue;
+			}
+
+			// Add our data array.
+			$build[ $id ]   = $terms;
+		}
+
+		// Now return the IDs.
+		return $build;
+	}
+
+	/**
+	 * Run the check for multi-category posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--counts]
+	 * : Whether to just show the counts.
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
+	 * [--single]
+	 * : How to determine which category to use.
+	 * ---
+	 * default: random
+	 * options:
+	 *   - random
+	 *   - first
+	 *   - last
+	 *   - popular
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp enforce-singlecat enforce
+	 *
+	 * @when after_wp_load
+	 */
+	function enforce( $args = array(), $assoc_args = array() ) {
+
+		// Parse out the associatives.
+		$parsed = wp_parse_args( $assoc_args, array(
+			'counts'    => false,
+			'single'    => 'random',
+		));
+
+		// Make sure that WooCommerce is installed and active.
+		$this->verify_woocommerce();
+
+		// Grab our list of releases, filtered.
+		$releases   = Functions\get_filtered_release_list();
+
+		// Throw an error and bail if we have no release data.
+		if ( ! $releases ) {
+			WP_CLI::error( 'No release data was found.' );
+		}
+
+		// Now loop the list of my releases, checking the versions.
+		foreach ( $releases as $version => $download ) {
+
+			// Prompt to continue the process if the autoloop wasn't set.
+			if ( ! $parsed['autoloop'] ) {
+				WP_CLI::confirm( sprintf( 'Do you want to install version %s?', esc_attr( $version ) ) );
+				WP_CLI::log( '' );
+			}
+
+			// Run the database backup if prompted.
+			if ( $parsed['backup'] ) {
+				$this->run_backup( $download, $version );
+			}
+
+			// Run our function to update.
+			$this->move_to_version( $download, $version );
+
+			// Run the Woo updater.
+			$this->run_woo_update();
+
+			// And clear out the object cache.
+			WP_CLI\Utils\wp_clear_object_cache();
+
+			// Finished with the item inside the loop, so return the success.
+			WP_CLI::success( sprintf( 'Success! You have updated WooCommerce to version %s', esc_attr( $version ) ) . "\n" );
+		}
+	}
+
+	/**
+	 * Run a quick numerical test.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp enforce-singlecat runtests
+	 *
+	 * @when after_wp_load
+	 */
+	function runtests() {
+
+		// Set my args.
+		$args   = array(
+			'return'     => true,   // Return 'STDOUT'; use 'all' for full object.
+			'parse'      => 'json', // Parse captured STDOUT to JSON array.
+			'launch'     => false,  // Reuse the current process.
+			'exit_error' => true,   // Halt script execution on error.
+		);
+
+		// Get my posts.
+		$posts  = WP_CLI::runcommand( 'post list --post_type=post --format=json', $args );
+
+		// This is blank, just here when I need it.
+	}
+
+	// End all custom CLI commands.
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -49,11 +49,16 @@ function check_admin_screen( $key = '' ) {
 			return $screen->id;
 			break;
 
+		case 'post_type' :
+			return $screen->post_type;
+			break;
+
 		default :
 			return array(
-				'action' => $screen->action,
-				'base'   => $screen->base,
-				'id'     => $screen->id
+				'action'    => $screen->action,
+				'base'      => $screen->base,
+				'id'        => $screen->id,
+				'post_type' => $screen->post_type,
 			);
 
 		// End all case breaks.
@@ -152,6 +157,9 @@ function get_dropdown_field( $post_id = 0, $args = array(), $hidden = true, $ech
 
 	// Call the actual dropdown.
 	$field .= wp_dropdown_categories( $setup );
+
+	// Include our nonce.
+	$field .= wp_nonce_field( 'enf_singlecat_nonce_action', 'enf_singlecat_nonce_name', false, false );
 
 	// Echo if requested.
 	if ( ! empty( $echo ) ) {

--- a/includes/post-edit.php
+++ b/includes/post-edit.php
@@ -51,7 +51,7 @@ function single_category_box( $post ) {
 	echo '<div id="taxonomy-category" class="categorydiv">';
 
 		// Call our dropdown function.
-		echo Helpers\get_dropdown_field( $post->ID );
+		echo Helpers\get_dropdown_field( $post->ID ); // WPCS: XSS ok.
 
 	// Close up the div.
 	echo '</div>';

--- a/includes/quick-edit.php
+++ b/includes/quick-edit.php
@@ -186,7 +186,7 @@ function display_category_quickedit( $column, $post_type ) {
 	// Close the fieldset.
 	$field .= '</fieldset>';
 
-    // And echo it out.
-    echo $field;
+	// And echo it out.
+	echo $field; // WPCS: XSS ok.
 }
 

--- a/includes/save-post.php
+++ b/includes/save-post.php
@@ -32,9 +32,14 @@ function enforce_on_save( $post_id, $post ) {
 	}
 
 	// Make sure the current user has the ability to save.
-    if ( ! current_user_can( 'edit_post', $post_id ) ) {
-        return;
-    }
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	// Check to see if our nonce was provided.
+	if ( empty( $_POST['enf_singlecat_nonce_name'] ) || ! wp_verify_nonce( $_POST['enf_singlecat_nonce_name'], 'enf_singlecat_nonce_action' ) ) {
+		return;
+	}
 
 	// Bail if we don't have categories at all (not sure why but ¯\_(ツ)_/¯ )
 	if ( empty( $_POST['post_category'] ) ) {

--- a/languages/enforce-single-category.pot
+++ b/languages/enforce-single-category.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Enforce Single Category 0.1.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/enforce-single-category\n"
-"POT-Creation-Date: 2018-06-01 14:05:49+00:00\n"
+"POT-Creation-Date: 2018-06-18 17:01:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,6 +24,26 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
+
+#: includes/commands.php:56
+msgid "No post IDs could be retrieved."
+msgstr ""
+
+#: includes/commands.php:82
+msgid "You have no posts with multiple categories assigned."
+msgstr ""
+
+#: includes/commands.php:209
+msgid "You have %d post with multiple categories assigned."
+msgid_plural "You have %d posts with multiple categories assigned."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/commands.php:252
+msgid "%d post has been updated."
+msgid_plural "%d posts have been updated."
+msgstr[0] ""
+msgstr[1] ""
 
 #: includes/post-edit.php:38 includes/quick-edit.php:68
 #: includes/quick-edit.php:172


### PR DESCRIPTION
Adding a CLI command to identify the posts with multiple categories, and provides the ability to re-assign them based on criteria.